### PR TITLE
Implement auto-closing notifications

### DIFF
--- a/src/containers/StatusMessage.tsx
+++ b/src/containers/StatusMessage.tsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAztecWallet } from '../hooks';
 import { useError } from '../providers/ErrorProvider';
 
 export const StatusMessage: React.FC = () => {
   const { error: walletError, isLoading, isInitialized } = useAztecWallet();
-  const { errors: globalErrors, clearError, clearAllErrors, hasErrors } = useError();
+  const {
+    errors: globalErrors,
+    clearError,
+    clearAllErrors,
+    hasErrors,
+  } = useError();
+  const [walletStatusVisible, setWalletStatusVisible] = useState(true);
 
   const renderStatus = () => {
     if (!isInitialized) {
@@ -24,7 +30,29 @@ export const StatusMessage: React.FC = () => {
 
   const statusText = renderStatus();
   const hasWalletError = walletError && isInitialized;
-  const shouldShow = statusText && isInitialized;
+  const shouldShow = statusText && isInitialized && walletStatusVisible;
+
+  // Auto-hide wallet status messages after timeout
+  useEffect(() => {
+    if (statusText && isInitialized) {
+      setWalletStatusVisible(true);
+
+      // Set timeout based on message type
+      const timeout = hasWalletError ? 8000 : 4000; // 8s for errors, 4s for info
+      const timeoutId = setTimeout(() => {
+        setWalletStatusVisible(false);
+      }, timeout);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [statusText, isInitialized, hasWalletError]);
+
+  // Reset visibility when status changes
+  useEffect(() => {
+    if (statusText) {
+      setWalletStatusVisible(true);
+    }
+  }, [statusText]);
 
   // Don't render if no status to show and no global errors
   if (!shouldShow && !hasErrors) {
@@ -35,25 +63,34 @@ export const StatusMessage: React.FC = () => {
     <div className="status-messages-container">
       {/* Wallet/Provider Status */}
       {shouldShow && (
-        <div 
-          id="status-message" 
+        <div
+          id="status-message"
           className={`status-message ${hasWalletError ? 'error' : 'info'}`}
         >
           {statusText}
+          <button
+            className={`error-close ${hasWalletError ? '' : 'info-close'}`}
+            onClick={() => setWalletStatusVisible(false)}
+            title="Dismiss message"
+          >
+            ×
+          </button>
         </div>
       )}
 
       {/* Global Errors */}
       {globalErrors.map((error) => (
-        <div 
+        <div
           key={error.id}
           className={`status-message ${error.type} global-error ${error.source ? `source-${error.source}` : ''}`}
         >
           <div className="error-header">
-            <span className={`error-source ${error.type === 'info' ? 'info-source' : ''}`}>
+            <span
+              className={`error-source ${error.type === 'info' ? 'info-source' : ''}`}
+            >
               {error.source || (error.type === 'info' ? 'Success' : 'Error')}
             </span>
-            <button 
+            <button
               className={`error-close ${error.type === 'info' ? 'info-close' : ''}`}
               onClick={() => clearError(error.id)}
               title="Dismiss message"
@@ -66,10 +103,7 @@ export const StatusMessage: React.FC = () => {
             <div className="error-details">{error.details}</div>
           )}
           {hasErrors && globalErrors.length > 1 && (
-            <button 
-              className="clear-all-errors"
-              onClick={clearAllErrors}
-            >
+            <button className="clear-all-errors" onClick={clearAllErrors}>
               Clear all messages
             </button>
           )}

--- a/src/providers/ErrorProvider.tsx
+++ b/src/providers/ErrorProvider.tsx
@@ -1,5 +1,36 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+  useRef,
+} from 'react';
 
+/**
+ * Configuration for notification messages with auto-timeout functionality.
+ *
+ * Auto-timeout behavior:
+ * - Info messages: 4 seconds (success notifications)
+ * - Warning messages: 6 seconds
+ * - Error messages: 8 seconds
+ *
+ * Usage examples:
+ * ```typescript
+ * // Auto-closing success message (default)
+ * addError({ message: 'Success!', type: 'info', source: 'voting' });
+ *
+ * // Custom timeout
+ * addError({ message: 'Custom timeout', type: 'info', timeout: 2000 });
+ *
+ * // Persistent message (no auto-close)
+ * addError({ message: 'Important error', type: 'error', autoClose: false });
+ *
+ * // Using utility functions
+ * addError(createAutoCloseMessage('Quick success', 'info', { timeout: 2000 }));
+ * addError(createPersistentMessage('Critical error', 'error'));
+ * ```
+ */
 export interface ErrorInfo {
   id: string;
   message: string;
@@ -7,6 +38,8 @@ export interface ErrorInfo {
   timestamp: Date;
   source?: string; // e.g., 'voting', 'dripper', 'wallet'
   details?: string;
+  autoClose?: boolean; // Whether this message should auto-close
+  timeout?: number; // Custom timeout in milliseconds
 }
 
 interface ErrorContextType {
@@ -24,26 +57,64 @@ interface ErrorProviderProps {
   children: ReactNode;
 }
 
+// Default timeout durations (in milliseconds)
+const DEFAULT_TIMEOUTS = {
+  info: 4000, // 4 seconds for success/info messages
+  warning: 6000, // 6 seconds for warnings
+  error: 8000, // 8 seconds for errors
+};
+
 export const ErrorProvider: React.FC<ErrorProviderProps> = ({ children }) => {
   const [errors, setErrors] = useState<ErrorInfo[]>([]);
+  const timeoutsRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
 
   const addError = (error: Omit<ErrorInfo, 'id' | 'timestamp'>) => {
     const newError: ErrorInfo = {
       ...error,
       id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
       timestamp: new Date(),
+      autoClose: error.autoClose !== false, // Default to true unless explicitly set to false
     };
-    
-    setErrors(prev => [newError, ...prev.slice(0, 4)]); // Keep only last 5 errors
+
+    setErrors((prev) => [newError, ...prev.slice(0, 4)]); // Keep only last 5 errors
+
+    // Set up auto-timeout if enabled
+    if (newError.autoClose) {
+      const timeout = newError.timeout || DEFAULT_TIMEOUTS[newError.type];
+      const timeoutId = setTimeout(() => {
+        clearError(newError.id);
+      }, timeout);
+
+      timeoutsRef.current.set(newError.id, timeoutId);
+    }
   };
 
   const clearError = (id: string) => {
-    setErrors(prev => prev.filter(error => error.id !== id));
+    // Clear any existing timeout for this error
+    const timeoutId = timeoutsRef.current.get(id);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutsRef.current.delete(id);
+    }
+
+    setErrors((prev) => prev.filter((error) => error.id !== id));
   };
 
   const clearAllErrors = () => {
+    // Clear all timeouts
+    timeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
+    timeoutsRef.current.clear();
+
     setErrors([]);
   };
+
+  // Cleanup timeouts on unmount
+  useEffect(() => {
+    return () => {
+      timeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutsRef.current.clear();
+    };
+  }, []);
 
   const hasErrors = errors.length > 0;
   const latestError = errors[0] || null;
@@ -71,3 +142,37 @@ export const useError = (): ErrorContextType => {
   }
   return context;
 };
+
+// Utility functions for common message patterns
+export const createAutoCloseMessage = (
+  message: string,
+  type: ErrorInfo['type'] = 'info',
+  options?: {
+    source?: string;
+    details?: string;
+    timeout?: number;
+    autoClose?: boolean;
+  }
+): Omit<ErrorInfo, 'id' | 'timestamp'> => ({
+  message,
+  type,
+  source: options?.source,
+  details: options?.details,
+  timeout: options?.timeout,
+  autoClose: options?.autoClose !== false, // Default to true
+});
+
+export const createPersistentMessage = (
+  message: string,
+  type: ErrorInfo['type'] = 'error',
+  options?: {
+    source?: string;
+    details?: string;
+  }
+): Omit<ErrorInfo, 'id' | 'timestamp'> => ({
+  message,
+  type,
+  source: options?.source,
+  details: options?.details,
+  autoClose: false, // Explicitly disable auto-close
+});

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -5,15 +5,15 @@ const proofTimeout = 300_000;
 test('app initialization and basic rendering', async ({ page }) => {
   await page.goto('/');
   await expect(page).toHaveTitle(/Private Voting on Aztec/);
-  
+
   // Wait for the app to be ready (connect button visible)
   const connectButton = await page.locator('#connect-test-account');
   await expect(connectButton).toBeVisible({ timeout: 30000 });
-  
+
   // Check that basic components are rendering
   const header = await page.locator('.navbar');
   await expect(header).toBeVisible();
-  
+
   const title = await page.locator('.nav-title');
   await expect(title).toHaveText('Private Voting');
 });
@@ -25,62 +25,61 @@ test('create account and cast vote', async ({ page }, testInfo) => {
   // Wait for the connect button to be visible (means app is ready)
   const connectTestAccount = await page.locator('#connect-test-account');
   await expect(connectTestAccount).toBeVisible({ timeout: 30000 });
-  
+
   const selectTestAccount = await page.locator('#test-account-number');
   await expect(selectTestAccount).toBeVisible();
 
   // Select different account for each browser
   const testAccountNumber = {
-    'chromium': 1,
-    'firefox': 2,
-    'webkit': 3,
+    chromium: 1,
+    firefox: 2,
+    webkit: 3,
   }[testInfo.project.name];
   await selectTestAccount.selectOption(testAccountNumber.toString());
 
   await connectTestAccount.click();
-  
+
   // Wait a moment for any errors to appear
   await page.waitForTimeout(2000);
-  
+
   // Check if there are any error messages visible
   const statusMessage = await page.locator('#status-message');
   if (await statusMessage.isVisible()) {
     const errorText = await statusMessage.textContent();
   }
-  
+
   // Wait for account to be connected and displayed
   // This can take time due to Aztec node communication
   const accountDisplay = await page.locator('#account-display');
   await expect(accountDisplay).toBeVisible({ timeout: 30000 });
   await expect(accountDisplay).toHaveText(/Account: 0x[a-fA-F0-9]{4}/);
-  
 
   // Wait for voting form to appear (only shows when account is connected)
   const voteButton = await page.locator('#vote-button');
   const voteInput = await page.locator('#vote-input');
   const voteResults = await page.locator('#vote-results');
-  
+
   await expect(voteInput).toBeVisible();
   await expect(voteButton).toBeVisible();
 
   // Choose the candidate to vote for based on the browser used to run the test.
   // This is a hack to avoid race conditions when tests are run in parallel against the same network.
   const candidateId = {
-    'chromium': 2,
-    'firefox': 3,
-    'webkit': 4,
+    chromium: 2,
+    firefox: 3,
+    webkit: 4,
   }[testInfo.project.name];
 
   await voteInput.selectOption(candidateId!.toString());
 
   // Wait for button to be enabled (requires candidate selection)
   await expect(voteButton).toBeEnabled();
-  
+
   await voteButton.click();
 
   // This will take some time to complete (Client IVC proof generation)
   // Wait for the voting process to complete
-  
+
   // Wait for the button to be enabled (voting process completed)
   await expect(voteButton).toBeEnabled({
     timeout: proofTimeout,
@@ -88,8 +87,69 @@ test('create account and cast vote', async ({ page }, testInfo) => {
 
   // Verify vote results - wait for results to load
   await expect(voteResults).toBeVisible();
-  
+
   // The vote results should show the candidate we voted for
   // Note: In a real scenario, this might take time to propagate
   await expect(voteResults).toContainText(`Candidate ${candidateId}`);
+});
+
+test('notification auto-timeout functionality', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/Private Voting on Aztec/);
+
+  // Wait for the app to be ready
+  const connectButton = await page.locator('#connect-test-account');
+  await expect(connectButton).toBeVisible({ timeout: 30000 });
+
+  // Connect to trigger a success message
+  await connectButton.click();
+
+  // Wait for account selection and select an account
+  const selectTestAccount = await page.locator('#test-account-number');
+  await expect(selectTestAccount).toBeVisible();
+  await selectTestAccount.selectOption('0');
+
+  const connectSelectedAccount = await page.locator(
+    '#connect-selected-account'
+  );
+  await expect(connectSelectedAccount).toBeVisible();
+  await connectSelectedAccount.click();
+
+  // Wait for a success message to appear
+  const statusMessage = await page.locator(
+    '.status-message.info, .status-message.global-error'
+  );
+
+  // Check if a message appears (it might be wallet initialization or connection success)
+  if (await statusMessage.isVisible()) {
+    // Verify the message is visible initially
+    await expect(statusMessage).toBeVisible();
+
+    // Wait for the message to auto-close (should happen within 4-8 seconds for info messages)
+    // We'll wait up to 10 seconds to be safe
+    await expect(statusMessage).not.toBeVisible({ timeout: 10000 });
+  }
+
+  // Test manual dismissal still works by triggering another action that shows a message
+  // Try to mint tokens to trigger a success message
+  const amountInput = await page.locator('#mint-amount');
+  if (await amountInput.isVisible()) {
+    await amountInput.fill('10');
+
+    const mintButton = await page.locator('#mint-public');
+    if (await mintButton.isVisible()) {
+      await mintButton.click();
+
+      // Wait for success message
+      const successMessage = await page.locator('.status-message.info');
+      if (await successMessage.isVisible()) {
+        // Verify we can manually dismiss it
+        const closeButton = await successMessage.locator('.error-close');
+        if (await closeButton.isVisible()) {
+          await closeButton.click();
+          await expect(successMessage).not.toBeVisible();
+        }
+      }
+    }
+  }
 });


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-XXX

Implements auto-closing notifications with configurable timeouts to improve user experience. Messages now automatically disappear after a set duration (defaulting to 4s for info, 6s for warnings, 8s for errors), while still allowing manual dismissal. This applies to both global error/status messages and wallet-specific status messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-c333ad82-b54e-4c4c-b41f-f6b73045d693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c333ad82-b54e-4c4c-b41f-f6b73045d693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

