### PR TITLE
Implement user-defined secret for account generation

### DIFF
--- a/src/components/SecretInputModal.tsx
+++ b/src/components/SecretInputModal.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+
+interface SecretInputModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (secretPhrase: string) => void;
+}
+
+export const SecretInputModal: React.FC<SecretInputModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
+  const [secretPhrase, setSecretPhrase] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!secretPhrase.trim()) {
+      setError('Secret phrase cannot be empty');
+      return;
+    }
+
+    onSubmit(secretPhrase.trim());
+    setSecretPhrase('');
+  };
+
+  const handleClose = () => {
+    setSecretPhrase('');
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={handleClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2>Enter Secret Phrase</h2>
+          <button
+            type="button"
+            className="modal-close-button"
+            onClick={handleClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <form onSubmit={handleSubmit}>
+          <div className="modal-body">
+            <label htmlFor="secret-phrase-input" className="modal-label">
+              Secret Phrase
+            </label>
+            <input
+              id="secret-phrase-input"
+              type="text"
+              className="modal-input"
+              value={secretPhrase}
+              onChange={(e) => {
+                setSecretPhrase(e.target.value);
+                setError(null);
+              }}
+              placeholder="Enter your secret phrase"
+              autoFocus
+            />
+            {error && <div className="modal-error">{error}</div>}
+            <p className="modal-help-text">
+              This secret phrase will be used to generate your Aztec account. Make sure to keep it secure.
+            </p>
+          </div>
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={handleClose}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+            >
+              Create Account
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { Tabs } from './Tabs';
 export { AddressDisplay } from './AddressDisplay';
+export { SecretInputModal } from './SecretInputModal';
 export * from './settings';

--- a/src/containers/Header.tsx
+++ b/src/containers/Header.tsx
@@ -5,7 +5,7 @@ export const Header: React.FC = () => {
   const { 
     connectedAccount, 
     isInitialized,
-    createAccount, 
+    openWalletSetup, 
     connectTestAccount, 
     connectExistingAccount,
     disconnectWallet
@@ -14,12 +14,8 @@ export const Header: React.FC = () => {
   const { currentConfig, switchToNetwork, getNetworkOptions } = useConfig();
   const [testAccountIndex, setTestAccountIndex] = useState(1);
 
-  const handleCreateAccount = async () => {
-    try {
-      await createAccount();
-    } catch (err) {
-      console.error('Failed to create account:', err);
-    }
+  const handleCreateAccount = () => {
+    openWalletSetup();
   };
 
   const handleConnectTestAccount = async () => {

--- a/src/providers/AztecWalletProvider.tsx
+++ b/src/providers/AztecWalletProvider.tsx
@@ -11,6 +11,7 @@ import {
 } from '../services/aztec/core';
 import { AztecDripperService, AztecTokenService, AztecSendersService } from '../services';
 import { isValidConfig } from '../utils';
+import { SecretInputModal } from '../components';
 
 interface AztecWalletContextType {
   // State
@@ -31,6 +32,7 @@ interface AztecWalletContextType {
   connectExistingAccount: () => Promise<void>;
   disconnectWallet: () => void;
   reinitialize: () => Promise<void>;
+  openWalletSetup: () => void;
 }
 
 export const AztecWalletContext = createContext<
@@ -54,6 +56,7 @@ export const AztecWalletProvider: React.FC<AztecWalletProviderProps> = ({
   );
   const [bridgeService, setBridgeService] = useState<any | null>(null);
   const [sendersService, setSendersService] = useState<AztecSendersService | null>(null);
+  const [showSecretModal, setShowSecretModal] = useState(false);
 
   const coreServicesRef = useRef<CoreServices | null>(null);
   const isInitializingRef = useRef(false);
@@ -142,6 +145,12 @@ export const AztecWalletProvider: React.FC<AztecWalletProviderProps> = ({
         );
         coreServicesRef.current = coreServices;
         setIsInitialized(true);
+        
+        // Check if account exists in storage, if not show modal
+        const storedAccount = coreServices.storageService.getAccount();
+        if (!storedAccount) {
+          setShowSecretModal(true);
+        }
       }, 'initialize core services');
     } catch (err) {
       console.error('Core services initialization failed:', err);
@@ -150,20 +159,33 @@ export const AztecWalletProvider: React.FC<AztecWalletProviderProps> = ({
     }
   };
 
-  const handleCreateAccount = async (): Promise<void> => {
+  const handleCreateAccount = async (secretPhrase?: string): Promise<void> => {
     return executeAsync(async () => {
       if (!coreServicesRef.current) {
         throw new Error('Core services not initialized');
       }
 
       // Create account without deploying
-      await coreServicesRef.current.walletService.createAccount();
+      await coreServicesRef.current.walletService.createAccount(secretPhrase);
       const account = coreServicesRef.current.walletService.getConnectedAccount();
 
       await coreServicesRef.current.walletService.deployAccount();
       
       setConnectedAccount(account);
+      setShowSecretModal(false);
     }, 'create account');
+  };
+
+  const openWalletSetup = () => {
+    setShowSecretModal(true);
+  };
+
+  const handleSecretSubmit = (secretPhrase: string) => {
+    handleCreateAccount(secretPhrase);
+  };
+
+  const handleSecretModalClose = () => {
+    setShowSecretModal(false);
   };
 
   const handleConnectTestAccount = async (index: number): Promise<void> => {
@@ -240,16 +262,22 @@ export const AztecWalletProvider: React.FC<AztecWalletProviderProps> = ({
     tokenService,
     bridgeService,
     sendersService,
-    createAccount: handleCreateAccount,
+    createAccount: () => handleCreateAccount(),
     connectTestAccount: handleConnectTestAccount,
     connectExistingAccount: handleConnectExistingAccount,
     disconnectWallet,
     reinitialize,
+    openWalletSetup,
   };
 
   return (
     <AztecWalletContext.Provider value={contextValue}>
       {children}
+      <SecretInputModal
+        isOpen={showSecretModal}
+        onClose={handleSecretModalClose}
+        onSubmit={handleSecretSubmit}
+      />
     </AztecWalletContext.Provider>
   );
 };

--- a/src/services/aztec/core/AztecWalletService.ts
+++ b/src/services/aztec/core/AztecWalletService.ts
@@ -79,12 +79,14 @@ export class AztecWalletService implements IAztecWalletService {
     return instance;
   }
 
-  private async getNewAccountCredentials(): Promise<{ secretKey: Fr, salt: Fr, signingKey: Buffer }> {
+  private async getNewAccountCredentials(secretPhrase?: string): Promise<{ secretKey: Fr, salt: Fr, signingKey: Buffer }> {
     // Generate a random salt, secret key, and signing key
-    const DEPLOYER_SECRET_PHRASE = process.env.DEPLOYER_SECRET_PHRASE || 'hola';
+    if (!secretPhrase) {
+      throw new Error('Secret phrase is required');
+    }
     const DEPLOYER_SALT = process.env.DEPLOYER_SALT || '1337';
     const DEPLOYER_SECRET = await poseidon2Hash([
-      Fr.fromBufferReduce(Buffer.from(DEPLOYER_SECRET_PHRASE.padEnd(32, '#'), 'utf8')),
+      Fr.fromBufferReduce(Buffer.from(secretPhrase.padEnd(32, '#'), 'utf8')),
     ]);
     const secretKey = DEPLOYER_SECRET;
     const salt = Fr.fromString(DEPLOYER_SALT); 
@@ -109,12 +111,12 @@ export class AztecWalletService implements IAztecWalletService {
     this.accountCredentials = { secretKey: account.secret, salt: account.salt, signingKey: account.signingKey.toBuffer() };
   }
 
-  private async createEcdsaAccount(): Promise<void> {
+  private async createEcdsaAccount(secretPhrase?: string): Promise<void> {
     if (!this.pxe) {
       throw new Error('PXE not initialized');
     }
 
-    const { secretKey, salt, signingKey } = await this.getNewAccountCredentials();
+    const { secretKey, salt, signingKey } = await this.getNewAccountCredentials(secretPhrase);
 
     const ecdsaAccount = await getEcdsaRAccount(
       this.pxe,
@@ -197,8 +199,8 @@ export class AztecWalletService implements IAztecWalletService {
   // HIGH-LEVEL ACCOUNT OPERATIONS
   // ========================================
 
-  async createAccount(): Promise<void> {
-    await this.createEcdsaAccount();
+  async createAccount(secretPhrase?: string): Promise<void> {
+    await this.createEcdsaAccount(secretPhrase);
     if (!this.connectedWallet || !this.accountCredentials) {
       throw new Error('No connected wallet or account credentials');
     }

--- a/src/style.css
+++ b/src/style.css
@@ -2018,3 +2018,125 @@ body {
     padding: 0.5rem;
   }
 }
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.modal-content {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  max-width: 500px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.modal-close-button {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  line-height: 1;
+  color: #64748b;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+.modal-close-button:hover {
+  background: #f1f5f9;
+  color: #1e293b;
+}
+
+.modal-body {
+  padding: 1.5rem;
+}
+
+.modal-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  color: #374151;
+  font-size: 0.875rem;
+}
+
+.modal-input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  background: #ffffff;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.modal-input:focus {
+  outline: none;
+  border-color: #8b5cf6;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+
+.modal-error {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: #fee2e2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+
+.modal-help-text {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.modal-footer {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  padding: 1.5rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.modal-footer .btn {
+  min-width: 100px;
+}

--- a/src/types/aztec.ts
+++ b/src/types/aztec.ts
@@ -45,7 +45,7 @@ export interface IAztecWalletService {
   
   // Account management
   connectTestAccount(index: number): Promise<void>;
-  createAccount(): Promise<void>;
+  createAccount(secretPhrase?: string): Promise<void>;
   connectExistingAccount(): Promise<void>;
   deployAccount(): Promise<string | null>;
   


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-XXX

Implements user-defined secret phrase input for Aztec account generation. This allows users to provide their own secret phrase, enhancing security and removing the previously hardcoded default. A modal now prompts for the secret phrase when an account needs to be created.

---
<a href="https://cursor.com/background-agent?bcId=bc-81463edb-fe06-4aad-a5ce-7ff17d0cdfcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81463edb-fe06-4aad-a5ce-7ff17d0cdfcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

